### PR TITLE
fix: typo in validate-it exercise method

### DIFF
--- a/examples/module1/lesson1/_solutions/validate-it/validation/methods.ts
+++ b/examples/module1/lesson1/_solutions/validate-it/validation/methods.ts
@@ -5,7 +5,7 @@ export type StringValidationMethod = (input: string) => boolean;
 
 const isEven: NumericValidationMethod = (input: number) => input % 2 === 0;
 
-const isGreatherThan = (boundary: number): NumericValidationMethod => {
+const isGreaterThan = (boundary: number): NumericValidationMethod => {
   return (input: number) => input > boundary;
 };
 
@@ -21,6 +21,6 @@ export const isValidInteger: StringValidationMethod = (
 
 export const NUMBER_VALIDATORS: NumericValidationMethod[] = [
   isEven,
-  isGreatherThan(0),
+  isGreaterThan(0),
   isLessThan(100),
 ];


### PR DESCRIPTION
This merge request corrects a typo in the method name used in the validate-it exercise solution.

Changes:

- Renamed `isGreatherThan` to `isGreaterThan` in all occurrences within the project.

This change ensures that the method name is now correctly spelled, aligning with common English conventions and improving the overall clarity of the code.